### PR TITLE
Introduce the short form for factory URL and use it where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Eclipse Che documentation project
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://github.com/eclipse/che-docs)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/#https://github.com/eclipse/che-docs)
 
 This repository contains sources for the [documentation for Eclipse Che](https://www.eclipse.org/che/docs/). To contribute to the documentation, see the [Contribution guide](CONTRIBUTING.adoc). We love pull requests and appreciate contributions that make docs more helpful for users.
 

--- a/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-into-a-workspace.adoc
+++ b/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-into-a-workspace.adoc
@@ -90,12 +90,12 @@ This approach brings an advantage of other users being able to contribute to the
 +
 .Factory URL pointing to a repository containing a devfile
 ====
-`pass:c,a,q[{prod-url}/f?url=https://github.com/eclipse/che]`
+`pass:c,a,q[{prod-url}/#https://github.com/eclipse/che]`
 ====
 +
 .Factory URL pointing to a devfile
 ====
-`pass:c,a,q[{prod-url}/f?url=https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml]`
+`pass:c,a,q[{prod-url}/#https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml]`
 ====
 
 . The reviewer starts a workspace by opening a link where they are able to starts a hosted plug-in instance and specify the path to the plug-in project inside the workspace. For instructions on how to start a hosted instance of Che-Theia for plug-in testing, see xref:testing-che-theia-plug-ins.adoc[].

--- a/modules/contributor-guide/partials/proc_testing-che-theia-with-custom-branding.adoc
+++ b/modules/contributor-guide/partials/proc_testing-che-theia-with-custom-branding.adoc
@@ -23,7 +23,7 @@ To test a custom Che-Theia image, create a new `meta.yaml` file describing a cus
 
 . Create a workspace using the sample https://github.com/che-samples/che-theia-branding-example/blob/master/devfile.yaml[che-theia-branding-example devfile] to apply the changes:
 +
-image::https://www.eclipse.org/che/contribute.svg[link="https://che.openshift.io/f?url=https://raw.githubusercontent.com/che-samples/che-theia-branding-example/master/devfile.yaml"]
+image::https://www.eclipse.org/che/contribute.svg[link="https://che.openshift.io/#https://raw.githubusercontent.com/che-samples/che-theia-branding-example/master/devfile.yaml"]
 +
 [source,yaml,attrs="nowrap"]
 ----

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-from-a-feature-branch-of-a-git-repository.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-from-a-feature-branch-of-a-git-repository.adoc
@@ -12,12 +12,12 @@ A {prod-short} workspace can be created by pointing to devfile that is stored in
 * The `devfile.yaml` or `.devfile.yaml` file is located in the root folder of a Git repository, on a specific branch of the user's choice that is accessible over HTTPS. See xref:configuring-a-workspace-using-a-devfile.adoc[] for detailed information about creating and using devfiles.
 
 .Procedure
-Execute the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=__<GitHubBranch>__]`
+Execute the workspace by opening the following URL: `pass:c,a,q[{prod-url}/#__<GitHubBranch>__]`
 
 .Example
 Use following URL format to open an experimental link:https://github.com/quarkusio/quarkus-quickstarts[quarkus-quickstarts] branch hosted on link:https://che.openshift.io[che.openshift.io].
 
 [subs="+quotes"]
 ----
-https://che.openshift.io/f?url=https://github.com/maxandersen/quarkus-quickstarts/tree/che
+https://che.openshift.io/#https://github.com/maxandersen/quarkus-quickstarts/tree/che
 ----

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
@@ -5,7 +5,8 @@
 [id="creating-a-workspace-from-the-default-branch-of-a-git-repository_{context}"]
 = Creating a workspace from the default branch of a Git repository
 
-It is possible to create a {prod-short} workspace by pointing to a devfile that is stored in a Git source repository. The {prod-short} instance then uses the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the factory URL (`/f?url=`) API.
+It is possible to create a {prod-short} workspace by pointing to a devfile that is stored in a Git source repository. The {prod-short} instance then uses the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the factory URL.
+There are two forms for factory URL, short one is /#$URL and long that supports additional configuration parameters `/f?url=$URL`.
 
 
 .Prerequisites
@@ -16,10 +17,10 @@ It is possible to create a {prod-short} workspace by pointing to a devfile that 
 
 .Procedure
 
-Run the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=https://__<GitRepository>__]`
+Run the workspace by opening the following URL: `pass:c,a,q[{prod-url}/#https://__<GitRepository>__]`
 
 .Example
 [subs="+quotes"]
 ----
-https://che.openshift.io/f?url=https://github.com/eclipse/che
+https://che.openshift.io/#https://github.com/eclipse/che
 ----

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-from-with-a-publicly-accessible-standalone-devfile-using-http.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-from-with-a-publicly-accessible-standalone-devfile-using-http.adoc
@@ -12,12 +12,12 @@ A workspace can be created using a devfile, the URL of which is pointing to the 
 * The publicly-accessible standalone `devfile.yaml` file. See xref:configuring-a-workspace-using-a-devfile.adoc[] for detailed information about creating and using devfiles.
 
 .Procedure
-. Execute the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=https://__<yourhosturl>__/devfile.yaml]`
+. Execute the workspace by opening the following URL: `pass:c,a,q[{prod-url}/#https://__<yourhosturl>__/devfile.yaml]`
 
 ifeval::["{project-context}" == "che"]
 .Example
 [subs="+quotes"]
 ----
-https://che.openshift.io/f?url=https://gist.githubusercontent.com/themr0c/ef8e59a162748a8be07e900b6401e6a8/raw/8802c20743cde712bbc822521463359a60d1f7a9/devfile.yaml
+https://che.openshift.io/#https://gist.githubusercontent.com/themr0c/ef8e59a162748a8be07e900b6401e6a8/raw/8802c20743cde712bbc822521463359a60d1f7a9/devfile.yaml
 ----
 endif::[]

--- a/modules/end-user-guide/partials/proc_testing-the-vs-code-extension-using-gist.adoc
+++ b/modules/end-user-guide/partials/proc_testing-the-vs-code-extension-using-gist.adoc
@@ -230,5 +230,5 @@ or:
 +
 [subs="+quotes"]
 ----
-$ echo "https://__<che-server>__/f?url=$(git config --get remote.origin.url)/raw/devfile.yaml"
+$ echo "https://__<che-server>__/#$(git config --get remote.origin.url)/raw/devfile.yaml"
 ----

--- a/modules/end-user-guide/partials/proc_using-a-badge-to-link-to-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_using-a-badge-to-link-to-workspaces.adoc
@@ -17,11 +17,11 @@ Use this badge and link it to a {prod-short} instance to quickly open a develope
 Add a link to your repository in the project `README` file. Using link:https://che.openshift.io[che.openshift.io] as an example {prod-short} host, and a GitHub repository:
 
 ----
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://github.com/org/repository)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/#https://github.com/org/repository)
 ----
 
 The snippet above creates a badge that opens a developer workspace of the repository at `+https://github.com/org/repository+` in link:https://che.openshift.io/[che.openshift.io]. To open a workspace in your {prod-short} installation, substitute your URL and repository:
 
 ----
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://your-che-host.com/f?url=https://your-repository-url)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://your-che-host.com/#https://your-repository-url)
 ----


### PR DESCRIPTION
Introduce the short form for factory URL and use it where possible

It was implemented in 7.26 and fixes https://github.com/eclipse/che/issues/18165 
but note that CRW needs to pull it along with a new dashboard, the latest plan is 2.8.